### PR TITLE
README.md: removed Project Euler duplicate

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,6 @@ See [Extended Contributing Guidelines](https://github.com/fnplus/interview-techd
 
 ### Coding Practices:
 
-* [Project Euler](https://projecteuler.net)
 * [LeetCode](https://leetcode.com/)
 * [InterviewBit](https://www.interviewbit.com/)
 * [Codility](https://codility.com/)


### PR DESCRIPTION
I found a duplicate in the `Coding Practices` section of the README, where `Project Euler` is listed twice.